### PR TITLE
check vector boundary before reading

### DIFF
--- a/mkmh.hpp
+++ b/mkmh.hpp
@@ -1011,7 +1011,7 @@ namespace mkmh{
         }
         std::sort(ret.begin(), ret.end());
         int nonzero_ind = 0;
-        while (ret[nonzero_ind] == 0){
+        while (nonzero_ind < ret.size() && ret[nonzero_ind] == 0){
             nonzero_ind++;
         }
 
@@ -1223,10 +1223,10 @@ namespace mkmh{
         ret.reserve(alpha.size());
         int i = 0;
         int j = 0;
-        while (alpha[i] == 0){
+        while (i < alpha.size() && alpha[i] == 0){
             i++;
         }
-        while(beta[j] == 0){
+        while(j < beta.size() && beta[j] == 0){
             j++;
         }
         while (i < alpha.size() && j < beta.size()){


### PR DESCRIPTION
Hi @edawson,

I stole a bit of your code to work on [smoothxg](https://github.com/pangenome/smoothxg/blob/80acc3221f802f40df232d6c894d3730bfadbd74/src/rkmh/rkmh.hpp#L4).

I am trying a mash-distance based sequence clustering and I detected some impolite memory accesses. Hope this PR can help you a bit in some way.

Ciao!